### PR TITLE
Make getaa more robust to RefSeq format

### DIFF
--- a/pangene.js
+++ b/pangene.js
@@ -1102,7 +1102,7 @@ function pg_cmd_getaa(args) {
 			}
 			continue;
 		}
-		if (gid != null && gene_type_dict[gid] !== "protein_coding") continue;
+		if ((gtype != null && gtype !== "protein_coding") || (gid != null && gene_type_dict[gid] !== "protein_coding")) continue;
 		if (canon_only && !canon) continue;
 		if (excl_decay && ttype !== "protein_coding") continue;
 		if (!keep_thru && thru) continue;

--- a/pangene.js
+++ b/pangene.js
@@ -1070,10 +1070,11 @@ function pg_cmd_getaa(args) {
 	}
 	const re = /([^\s"]+) "([^\s"]+)"/g;
 	let h = {};
+	let gene_type_dict = {};
 	for (const line of k8_readline(args[0])) { // read symbols
 		if (line[0] == '#') continue;
 		let m, t = line.split("\t");
-		if (t[2] !== "CDS") continue;
+		if (t[2] !== "CDS" && t[2] !== "gene") continue;
 		if (t[0] === "MT" || t[0] === "chrM" || t[0] === "chrMT") continue;
 		let gid = null, gname = null, pid = null, pver = null, ttype = null, gtype = null, thru = false, canon = false;
 		while ((m = re.exec(t[8])) != null) {
@@ -1095,7 +1096,13 @@ function pg_cmd_getaa(args) {
 				canon = true;
 			}
 		}
-		if (gtype !== "protein_coding") continue;
+		if (t[2] === "gene") {
+			if (gid != null && gtype != null) {
+				gene_type_dict[gid] = gtype;
+			}
+			continue;
+		}
+		if (gid != null && gene_type_dict[gid] !== "protein_coding") continue;
 		if (canon_only && !canon) continue;
 		if (excl_decay && ttype !== "protein_coding") continue;
 		if (!keep_thru && thru) continue;


### PR DESCRIPTION
It seems RefSeq (at least for Bos taurus) only has the gene_(bio)type entry on the gene entries and not CDS entries, so all input was lost. Since the gene entry always comes before CDS, we can get the gene_(bio)type then, and then lookup the type during CDS entries.

Should be backward compatible, since the gene_(bio)type of a CDS entry should surely match the gene entry, and if only CDSs are present, it can check for protein_coding there. 